### PR TITLE
bugfix: card details arrow logic

### DIFF
--- a/GitHub GameOff Game Jam 2022/Assets/Scripts/UI/Cards/UIInspectorPanel.cs
+++ b/GitHub GameOff Game Jam 2022/Assets/Scripts/UI/Cards/UIInspectorPanel.cs
@@ -138,18 +138,7 @@ public class UIInspectorPanel : MonoBehaviour
 
     private void SetupArrowButtons()
     {
-        if (currentIndex == 0)
-        {
-            priorButton.interactable = false;
-        }
-        else if (currentIndex == CardManager.Instance.GetHandcardSize() - 1)
-        {
-            nextButton.interactable = false;
-        }
-        else
-        {
-            priorButton.interactable = true;
-            nextButton.interactable = true;
-        }
+        priorButton.interactable = currentIndex > 0;
+        nextButton.interactable = currentIndex < CardManager.Instance.GetHandcardSize() - 1;
     }
 }


### PR DESCRIPTION
scenario fixed:
1. right click card 0, left arrow will be disabled.
2. close details panel.
3. right click right-most card. right arrow will be disabled and left arrow will still be disabled (incorrectly).